### PR TITLE
Removed redundant if/else checks in NeuroUtils

### DIFF
--- a/src/org/neurovillage/main/NeuroUtils.java
+++ b/src/org/neurovillage/main/NeuroUtils.java
@@ -8,11 +8,7 @@ public class NeuroUtils {
 	{
 		HashMap<String,Float> lookUpTable = new HashMap<String, Float>();
 		
-		float range = 0;
-		if (((startVal<0) && (endVal<0)) || ((startVal>0) && (endVal>0)))
-			range = Math.abs(startVal - endVal);
-		else
-			range = Math.abs(startVal) +  Math.abs(endVal); 
+		float range = Math.abs(startVal - endVal); 
 		
 		float step = range / (float)val;
 		float curVal = startVal;


### PR DESCRIPTION
Fixes #4 

**Changes**: Changed the 'getHexLookUpTable' method of NeuroUtils class to calculate range as Math.abs(startVal - endVal) and thus not needing checks through additional if/else statement.

**Checklist**:

* [x]  I have reformatted code in every file included in this PR [CTRL+ALT+L]
* [x]  My code does not contain any extra lines or extra spaces
* [x]  I have requested reviews from other members
